### PR TITLE
fix for #123

### DIFF
--- a/src/main/java/net/orcinus/galosphere/Galosphere.java
+++ b/src/main/java/net/orcinus/galosphere/Galosphere.java
@@ -28,6 +28,7 @@ import net.orcinus.galosphere.init.GItems;
 import net.orcinus.galosphere.init.GMemoryModuleTypes;
 import net.orcinus.galosphere.init.GMenuTypes;
 import net.orcinus.galosphere.init.GMobEffects;
+import net.orcinus.galosphere.init.GNetwork;
 import net.orcinus.galosphere.init.GParticleTypes;
 import net.orcinus.galosphere.init.GPlacedFeatures;
 import net.orcinus.galosphere.init.GPotions;
@@ -69,6 +70,7 @@ public class Galosphere implements ModInitializer {
         GRecipeSerializers.init();
         GStructureProcessorTypes.init();
         GVanillaIntegration.init();
+        GNetwork.init();
 
         SpawnPlacements.register(GEntityTypes.SPARKLE, SpawnPlacementTypes.ON_GROUND, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, Sparkle::checkSparkleSpawnRules);
         SpawnPlacements.register(GEntityTypes.SPECTRE, SpawnPlacementTypes.NO_RESTRICTIONS, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, Spectre::checkSpectreSpawnRules);
@@ -82,3 +84,4 @@ public class Galosphere implements ModInitializer {
     }
 
 }
+

--- a/src/main/java/net/orcinus/galosphere/GalosphereClient.java
+++ b/src/main/java/net/orcinus/galosphere/GalosphereClient.java
@@ -126,7 +126,7 @@ public class GalosphereClient implements ClientModInitializer {
         EntityModelLayerRegistry.registerModelLayer(GModelLayers.PRESERVED, PreservedModel::createBodyLayer);
 
         GEvents.clientInit();
-        GNetwork.init();
+        GNetwork.initClient();
 
         ItemProperties.register(Items.CROSSBOW, Galosphere.id("glow_flare"), (stack, world, entity, i) -> {
             ChargedProjectiles chargedProjectiles = stack.get(DataComponents.CHARGED_PROJECTILES);

--- a/src/main/java/net/orcinus/galosphere/blocks/blockentities/GlowInkClumpsBlockEntity.java
+++ b/src/main/java/net/orcinus/galosphere/blocks/blockentities/GlowInkClumpsBlockEntity.java
@@ -18,7 +18,7 @@ import net.minecraft.world.level.levelgen.feature.DripstoneUtils;
 import net.orcinus.galosphere.blocks.GlowInkClumpsBlock;
 import net.orcinus.galosphere.init.GBlockEntityTypes;
 import net.orcinus.galosphere.init.GBlocks;
-import net.orcinus.galosphere.network.SendParticlesPacket;
+import net.orcinus.galosphere.network.ServerPacketTypes;
 
 public class GlowInkClumpsBlockEntity  extends BlockEntity {
     private static int delay = 0;
@@ -57,7 +57,7 @@ public class GlowInkClumpsBlockEntity  extends BlockEntity {
                                 if (delay == 0) {
                                     if (!world.isClientSide()) {
                                         for (ServerPlayer serverPlayer : PlayerLookup.tracking((ServerLevel) world, offset)) {
-                                            ServerPlayNetworking.send(serverPlayer, new SendParticlesPacket(offset));
+                                            ServerPlayNetworking.send(serverPlayer, new ServerPacketTypes.ServerSendParticlesPacket(offset));
                                         }
                                     }
                                     int age = 0;

--- a/src/main/java/net/orcinus/galosphere/entities/Spectre.java
+++ b/src/main/java/net/orcinus/galosphere/entities/Spectre.java
@@ -69,7 +69,7 @@ import net.orcinus.galosphere.init.GParticleTypes;
 import net.orcinus.galosphere.init.GSensorTypes;
 import net.orcinus.galosphere.init.GSoundEvents;
 import net.orcinus.galosphere.items.components.SpectreBound;
-import net.orcinus.galosphere.network.SendPerspectivePacket;
+import net.orcinus.galosphere.network.ServerPacketTypes;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
@@ -378,7 +378,7 @@ public class Spectre extends Animal implements FlyingAnimal, BottlePickable, Spe
         if (!this.level().isClientSide()) {
             ((SpectreBoundSpyglass)player).setUsingSpectreBoundedSpyglass(true);
             this.setManipulatorUUID(player.getUUID());
-            ServerPlayNetworking.send((ServerPlayer) player, new SendPerspectivePacket(player.getUUID(), this.getId()));
+            ServerPlayNetworking.send((ServerPlayer) player, new ServerPacketTypes.ServerSendPerspectivePacket(player.getUUID(), this.getId()));
             player.playNotifySound(GSoundEvents.SPECTRE_MANIPULATE_BEGIN, getSoundSource(), 1, 1);
         }
     }

--- a/src/main/java/net/orcinus/galosphere/entities/SpectreFlare.java
+++ b/src/main/java/net/orcinus/galosphere/entities/SpectreFlare.java
@@ -18,7 +18,7 @@ import net.orcinus.galosphere.init.GEntityTypes;
 import net.orcinus.galosphere.init.GItems;
 import net.orcinus.galosphere.init.GSoundEvents;
 import net.orcinus.galosphere.mixin.access.FireworkRocketEntityAccessor;
-import net.orcinus.galosphere.network.SendPerspectivePacket;
+import net.orcinus.galosphere.network.ServerPacketTypes;
 import org.jetbrains.annotations.Nullable;
 
 public class SpectreFlare extends ThrowableLaunchedProjectile {
@@ -75,7 +75,7 @@ public class SpectreFlare extends ThrowableLaunchedProjectile {
                 serverPlayer.playNotifySound(GSoundEvents.SPECTRE_MANIPULATE_BEGIN, getSoundSource(), 1, 1);
                 world.addFreshEntity(spectatorVision);
                 ((SpectreBoundSpyglass)serverPlayer).setUsingSpectreBoundedSpyglass(true);
-                ServerPlayNetworking.send(serverPlayer, new SendPerspectivePacket(serverPlayer.getUUID(), spectatorVision.getId()));
+                ServerPlayNetworking.send(serverPlayer, new ServerPacketTypes.ServerSendPerspectivePacket(serverPlayer.getUUID(), spectatorVision.getId()));
             }
         }
     }

--- a/src/main/java/net/orcinus/galosphere/init/GEvents.java
+++ b/src/main/java/net/orcinus/galosphere/init/GEvents.java
@@ -41,7 +41,7 @@ import net.orcinus.galosphere.api.Spectatable;
 import net.orcinus.galosphere.api.SpectreBoundSpyglass;
 import net.orcinus.galosphere.blocks.LumiereComposterBlock;
 import net.orcinus.galosphere.config.GalosphereConfig;
-import net.orcinus.galosphere.network.BarometerPacket;
+import net.orcinus.galosphere.network.ServerPacketTypes;
 import net.orcinus.galosphere.util.BannerRendererUtil;
 import net.orcinus.galosphere.util.PreservedShulkerBox;
 
@@ -73,7 +73,7 @@ public class GEvents {
             level.getPlayers((player) -> player.level() != null).forEach((player) -> {
                 ServerLevelData levelData = (ServerLevelData) level.getLevelData();
                 int rainTime = levelData.getClearWeatherTime() > 0 ? levelData.getClearWeatherTime() : levelData.getRainTime();
-                ServerPlayNetworking.send(player, new BarometerPacket(rainTime));
+                ServerPlayNetworking.send(player, new ServerPacketTypes.ServerBarometerPacket(rainTime));
             });
         });
     }

--- a/src/main/java/net/orcinus/galosphere/init/GNetwork.java
+++ b/src/main/java/net/orcinus/galosphere/init/GNetwork.java
@@ -2,28 +2,22 @@ package net.orcinus.galosphere.init;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
-import net.orcinus.galosphere.network.BarometerPacket;
-import net.orcinus.galosphere.network.PlayCooldownSoundPacket;
-import net.orcinus.galosphere.network.SendParticlesPacket;
-import net.orcinus.galosphere.network.SendPerspectivePacket;
+import net.orcinus.galosphere.network.ServerPacketTypes;
 
 public class GNetwork {
 
-    @Environment(EnvType.CLIENT)
     public static void init() {
-        PayloadTypeRegistry.playS2C().register(SendParticlesPacket.TYPE, SendParticlesPacket.STREAM_CODEC);
-        ClientPlayNetworking.registerGlobalReceiver(SendParticlesPacket.TYPE, SendParticlesPacket::receive);
+        // Register server-safe packet types
+        ServerPacketTypes.register();
+    }
 
-        PayloadTypeRegistry.playS2C().register(SendPerspectivePacket.TYPE, SendPerspectivePacket.STREAM_CODEC);
-        ClientPlayNetworking.registerGlobalReceiver(SendPerspectivePacket.TYPE, SendPerspectivePacket::receive);
-
-        PayloadTypeRegistry.playS2C().register(BarometerPacket.TYPE, BarometerPacket.STREAM_CODEC);
-        ClientPlayNetworking.registerGlobalReceiver(BarometerPacket.TYPE, BarometerPacket::receive);
-
-        PayloadTypeRegistry.playS2C().register(PlayCooldownSoundPacket.TYPE, PlayCooldownSoundPacket.STREAM_CODEC);
-        ClientPlayNetworking.registerGlobalReceiver(PlayCooldownSoundPacket.TYPE, PlayCooldownSoundPacket::receive);
+    @Environment(EnvType.CLIENT)
+    public static void initClient() {
+        // Register client-side packet handlers
+        net.orcinus.galosphere.network.SendParticlesPacket.register();
+        net.orcinus.galosphere.network.SendPerspectivePacket.register();
+        net.orcinus.galosphere.network.BarometerPacket.register();
+        net.orcinus.galosphere.network.PlayCooldownSoundPacket.register();
     }
 
 }

--- a/src/main/java/net/orcinus/galosphere/mixin/ServerItemCooldownsMixin.java
+++ b/src/main/java/net/orcinus/galosphere/mixin/ServerItemCooldownsMixin.java
@@ -5,7 +5,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ServerItemCooldowns;
 import net.orcinus.galosphere.init.GItems;
-import net.orcinus.galosphere.network.PlayCooldownSoundPacket;
+import net.orcinus.galosphere.network.ServerPacketTypes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -23,7 +23,7 @@ public class ServerItemCooldownsMixin {
     @Inject(at = @At("TAIL"), method = "onCooldownEnded")
     private void G$removeCooldown(Item item, CallbackInfo ci) {
         if (item.equals(GItems.SALTBOUND_TABLET)) {
-            ServerPlayNetworking.send(this.player, new PlayCooldownSoundPacket());
+            ServerPlayNetworking.send(this.player, new ServerPacketTypes.ServerPlayCooldownSoundPacket());
         }
     }
 

--- a/src/main/java/net/orcinus/galosphere/network/BarometerPacket.java
+++ b/src/main/java/net/orcinus/galosphere/network/BarometerPacket.java
@@ -10,11 +10,17 @@ import net.orcinus.galosphere.GalosphereClient;
 
 public record BarometerPacket(int time) implements CustomPacketPayload {
     public static final Type<BarometerPacket> TYPE = new Type<>(Galosphere.id("barometer_info"));
-    public static final StreamCodec<FriendlyByteBuf, BarometerPacket> STREAM_CODEC = CustomPacketPayload.codec(BarometerPacket::write, BarometerPacket::new);
+    public static final StreamCodec<FriendlyByteBuf, BarometerPacket> STREAM_CODEC = new StreamCodec<FriendlyByteBuf, BarometerPacket>() {
+        @Override
+        public BarometerPacket decode(FriendlyByteBuf buf) {
+            return new BarometerPacket(buf.readInt());
+        }
 
-    private BarometerPacket(FriendlyByteBuf buf) {
-        this(buf.readInt());
-    }
+        @Override
+        public void encode(FriendlyByteBuf buf, BarometerPacket packet) {
+            buf.writeInt(packet.time());
+        }
+    };
 
     public void write(FriendlyByteBuf friendlyByteBuf) {
         friendlyByteBuf.writeInt(this.time);
@@ -28,5 +34,14 @@ public record BarometerPacket(int time) implements CustomPacketPayload {
     @Override
     public Type<? extends CustomPacketPayload> type() {
         return TYPE;
+    }
+
+    public static void register() {
+        // Register receiver for the server packet type
+        ClientPlayNetworking.registerGlobalReceiver(net.orcinus.galosphere.network.ServerPacketTypes.BAROMETER_TYPE, (packet, context) -> {
+            // Convert server packet to client packet and handle
+            BarometerPacket clientPacket = new BarometerPacket(packet.time());
+            clientPacket.receive(context);
+        });
     }
 }

--- a/src/main/java/net/orcinus/galosphere/network/PlayCooldownSoundPacket.java
+++ b/src/main/java/net/orcinus/galosphere/network/PlayCooldownSoundPacket.java
@@ -11,11 +11,17 @@ import net.orcinus.galosphere.init.GSoundEvents;
 
 public record PlayCooldownSoundPacket() implements CustomPacketPayload {
     public static final Type<PlayCooldownSoundPacket> TYPE = new Type<>(Galosphere.id("play_cooldown_sound"));
-    public static final StreamCodec<FriendlyByteBuf, PlayCooldownSoundPacket> STREAM_CODEC = CustomPacketPayload.codec(PlayCooldownSoundPacket::write, PlayCooldownSoundPacket::new);
+    public static final StreamCodec<FriendlyByteBuf, PlayCooldownSoundPacket> STREAM_CODEC = new StreamCodec<FriendlyByteBuf, PlayCooldownSoundPacket>() {
+        @Override
+        public PlayCooldownSoundPacket decode(FriendlyByteBuf buf) {
+            return new PlayCooldownSoundPacket();
+        }
 
-    private PlayCooldownSoundPacket(FriendlyByteBuf buf) {
-        this();
-    }
+        @Override
+        public void encode(FriendlyByteBuf buf, PlayCooldownSoundPacket packet) {
+            // No data to encode for this packet
+        }
+    };
 
     public void write(FriendlyByteBuf friendlyByteBuf) {
     }
@@ -30,5 +36,14 @@ public record PlayCooldownSoundPacket() implements CustomPacketPayload {
     @Override
     public Type<? extends CustomPacketPayload> type() {
         return TYPE;
+    }
+
+    public static void register() {
+        // Register receiver for the server packet type (packet type already registered by ServerPacketTypes)
+        ClientPlayNetworking.registerGlobalReceiver(net.orcinus.galosphere.network.ServerPacketTypes.PLAY_COOLDOWN_SOUND_TYPE, (packet, context) -> {
+            // Convert server packet to client packet and handle
+            PlayCooldownSoundPacket clientPacket = new PlayCooldownSoundPacket();
+            clientPacket.receive(context);
+        });
     }
 }

--- a/src/main/java/net/orcinus/galosphere/network/SendParticlesPacket.java
+++ b/src/main/java/net/orcinus/galosphere/network/SendParticlesPacket.java
@@ -15,11 +15,17 @@ import net.orcinus.galosphere.init.GSoundEvents;
 
 public record SendParticlesPacket(BlockPos blockPos) implements CustomPacketPayload {
     public static final Type<SendParticlesPacket> TYPE = new Type<>(Galosphere.id("send_particles"));
-    public static final StreamCodec<FriendlyByteBuf, SendParticlesPacket> STREAM_CODEC = CustomPacketPayload.codec(SendParticlesPacket::write, SendParticlesPacket::new);
+    public static final StreamCodec<FriendlyByteBuf, SendParticlesPacket> STREAM_CODEC = new StreamCodec<FriendlyByteBuf, SendParticlesPacket>() {
+        @Override
+        public SendParticlesPacket decode(FriendlyByteBuf buf) {
+            return new SendParticlesPacket(buf.readBlockPos());
+        }
 
-    private SendParticlesPacket(FriendlyByteBuf friendlyByteBuf) {
-        this(friendlyByteBuf.readBlockPos());
-    }
+        @Override
+        public void encode(FriendlyByteBuf buf, SendParticlesPacket packet) {
+            buf.writeBlockPos(packet.blockPos());
+        }
+    };
 
     public void write(FriendlyByteBuf friendlyByteBuf) {
         friendlyByteBuf.writeBlockPos(this.blockPos);
@@ -49,5 +55,14 @@ public record SendParticlesPacket(BlockPos blockPos) implements CustomPacketPayl
     @Override
     public Type<? extends CustomPacketPayload> type() {
         return TYPE;
+    }
+
+    public static void register() {
+        // Register receiver for the server packet type (packet type already registered by ServerPacketTypes)
+        ClientPlayNetworking.registerGlobalReceiver(net.orcinus.galosphere.network.ServerPacketTypes.SEND_PARTICLES_TYPE, (packet, context) -> {
+            // Convert server packet to client packet and handle
+            SendParticlesPacket clientPacket = new SendParticlesPacket(packet.blockPos());
+            clientPacket.receive(context);
+        });
     }
 }

--- a/src/main/java/net/orcinus/galosphere/network/SendPerspectivePacket.java
+++ b/src/main/java/net/orcinus/galosphere/network/SendPerspectivePacket.java
@@ -14,11 +14,18 @@ import java.util.UUID;
 
 public record SendPerspectivePacket(UUID uuid, int id) implements CustomPacketPayload {
     public static final Type<SendPerspectivePacket> TYPE = new Type<>(Galosphere.id("send_perspective"));
-    public static final StreamCodec<FriendlyByteBuf, SendPerspectivePacket> STREAM_CODEC = CustomPacketPayload.codec(SendPerspectivePacket::write, SendPerspectivePacket::new);
+    public static final StreamCodec<FriendlyByteBuf, SendPerspectivePacket> STREAM_CODEC = new StreamCodec<FriendlyByteBuf, SendPerspectivePacket>() {
+        @Override
+        public SendPerspectivePacket decode(FriendlyByteBuf buf) {
+            return new SendPerspectivePacket(buf.readUUID(), buf.readInt());
+        }
 
-    private SendPerspectivePacket(FriendlyByteBuf buf) {
-        this(buf.readUUID(), buf.readInt());
-    }
+        @Override
+        public void encode(FriendlyByteBuf buf, SendPerspectivePacket packet) {
+            buf.writeUUID(packet.uuid());
+            buf.writeInt(packet.id());
+        }
+    };
 
     public void write(FriendlyByteBuf friendlyByteBuf) {
         friendlyByteBuf.writeUUID(this.uuid);
@@ -43,5 +50,14 @@ public record SendPerspectivePacket(UUID uuid, int id) implements CustomPacketPa
     @Override
     public Type<? extends CustomPacketPayload> type() {
         return TYPE;
+    }
+
+    public static void register() {
+        // Register receiver for the server packet type (packet type already registered by ServerPacketTypes)
+        ClientPlayNetworking.registerGlobalReceiver(net.orcinus.galosphere.network.ServerPacketTypes.SEND_PERSPECTIVE_TYPE, (packet, context) -> {
+            // Convert server packet to client packet and handle
+            SendPerspectivePacket clientPacket = new SendPerspectivePacket(packet.uuid(), packet.id());
+            clientPacket.receive(context);
+        });
     }
 }

--- a/src/main/java/net/orcinus/galosphere/network/ServerPacketTypes.java
+++ b/src/main/java/net/orcinus/galosphere/network/ServerPacketTypes.java
@@ -1,0 +1,108 @@
+package net.orcinus.galosphere.network;
+
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.orcinus.galosphere.Galosphere;
+
+/**
+ * Server-safe packet type definitions without client-side imports
+ */
+public class ServerPacketTypes {
+    
+    // Packet types
+    public static final CustomPacketPayload.Type<ServerBarometerPacket> BAROMETER_TYPE = 
+        new CustomPacketPayload.Type<>(Galosphere.id("barometer_info"));
+    public static final CustomPacketPayload.Type<ServerPlayCooldownSoundPacket> PLAY_COOLDOWN_SOUND_TYPE = 
+        new CustomPacketPayload.Type<>(Galosphere.id("play_cooldown_sound"));
+    public static final CustomPacketPayload.Type<ServerSendParticlesPacket> SEND_PARTICLES_TYPE = 
+        new CustomPacketPayload.Type<>(Galosphere.id("send_particles"));
+    public static final CustomPacketPayload.Type<ServerSendPerspectivePacket> SEND_PERSPECTIVE_TYPE = 
+        new CustomPacketPayload.Type<>(Galosphere.id("send_perspective"));
+
+    // Server-safe packet implementations
+    public record ServerBarometerPacket(int time) implements CustomPacketPayload {
+        public static final StreamCodec<FriendlyByteBuf, ServerBarometerPacket> STREAM_CODEC = new StreamCodec<FriendlyByteBuf, ServerBarometerPacket>() {
+            @Override
+            public ServerBarometerPacket decode(FriendlyByteBuf buf) {
+                return new ServerBarometerPacket(buf.readInt());
+            }
+
+            @Override
+            public void encode(FriendlyByteBuf buf, ServerBarometerPacket packet) {
+                buf.writeInt(packet.time());
+            }
+        };
+
+        @Override
+        public Type<? extends CustomPacketPayload> type() {
+            return BAROMETER_TYPE;
+        }
+    }
+
+    public record ServerPlayCooldownSoundPacket() implements CustomPacketPayload {
+        public static final StreamCodec<FriendlyByteBuf, ServerPlayCooldownSoundPacket> STREAM_CODEC = new StreamCodec<FriendlyByteBuf, ServerPlayCooldownSoundPacket>() {
+            @Override
+            public ServerPlayCooldownSoundPacket decode(FriendlyByteBuf buf) {
+                return new ServerPlayCooldownSoundPacket();
+            }
+
+            @Override
+            public void encode(FriendlyByteBuf buf, ServerPlayCooldownSoundPacket packet) {
+                // No data to encode
+            }
+        };
+
+        @Override
+        public Type<? extends CustomPacketPayload> type() {
+            return PLAY_COOLDOWN_SOUND_TYPE;
+        }
+    }
+
+    public record ServerSendParticlesPacket(net.minecraft.core.BlockPos blockPos) implements CustomPacketPayload {
+        public static final StreamCodec<FriendlyByteBuf, ServerSendParticlesPacket> STREAM_CODEC = new StreamCodec<FriendlyByteBuf, ServerSendParticlesPacket>() {
+            @Override
+            public ServerSendParticlesPacket decode(FriendlyByteBuf buf) {
+                return new ServerSendParticlesPacket(buf.readBlockPos());
+            }
+
+            @Override
+            public void encode(FriendlyByteBuf buf, ServerSendParticlesPacket packet) {
+                buf.writeBlockPos(packet.blockPos());
+            }
+        };
+
+        @Override
+        public Type<? extends CustomPacketPayload> type() {
+            return SEND_PARTICLES_TYPE;
+        }
+    }
+
+    public record ServerSendPerspectivePacket(java.util.UUID uuid, int id) implements CustomPacketPayload {
+        public static final StreamCodec<FriendlyByteBuf, ServerSendPerspectivePacket> STREAM_CODEC = new StreamCodec<FriendlyByteBuf, ServerSendPerspectivePacket>() {
+            @Override
+            public ServerSendPerspectivePacket decode(FriendlyByteBuf buf) {
+                return new ServerSendPerspectivePacket(buf.readUUID(), buf.readInt());
+            }
+
+            @Override
+            public void encode(FriendlyByteBuf buf, ServerSendPerspectivePacket packet) {
+                buf.writeUUID(packet.uuid());
+                buf.writeInt(packet.id());
+            }
+        };
+
+        @Override
+        public Type<? extends CustomPacketPayload> type() {
+            return SEND_PERSPECTIVE_TYPE;
+        }
+    }
+
+    public static void register() {
+        PayloadTypeRegistry.playS2C().register(BAROMETER_TYPE, ServerBarometerPacket.STREAM_CODEC);
+        PayloadTypeRegistry.playS2C().register(PLAY_COOLDOWN_SOUND_TYPE, ServerPlayCooldownSoundPacket.STREAM_CODEC);
+        PayloadTypeRegistry.playS2C().register(SEND_PARTICLES_TYPE, ServerSendParticlesPacket.STREAM_CODEC);
+        PayloadTypeRegistry.playS2C().register(SEND_PERSPECTIVE_TYPE, ServerSendPerspectivePacket.STREAM_CODEC);
+    }
+}


### PR DESCRIPTION
fixes #123 
a rewrite of the packet system that runs fine on client and server alike.

tl;dr

>all CustomPacketPayload.codec() calls replaced with anonymous StreamCodec implementations

>server-side packet sending updated to use ServerPacketTypes.ServerXxxPacket

>client-side receivers register for server packet types and convert to client packets